### PR TITLE
Fix header_lote_cobranca.json

### DIFF
--- a/cnab240/bancos/banco_brasil/specs/header_lote_cobranca.json
+++ b/cnab240/bancos/banco_brasil/specs/header_lote_cobranca.json
@@ -43,8 +43,8 @@
       "nome": "vazio1",
       "posicao_inicio": 12,
       "posicao_fim": 13,
-      "formato": "num",
-      "default": 0
+      "formato": "alfa",
+      "default": ""
     },
 
     "07.1": {


### PR DESCRIPTION
Erro no validador causado por  preencher com zeros onde deveria estar preenchendo com espaço em branco